### PR TITLE
Don't warn on unsupported features

### DIFF
--- a/sigma_/update_server.py
+++ b/sigma_/update_server.py
@@ -25,7 +25,7 @@ class SigmaUpdateServer(ServiceUpdater):
             except ComposerError:
                 self.log.warning(f"{file} failed to import due to a YAML-parsing error")
             except UnsupportedFeature as e:
-                self.log.warning(f'{file} | {e}')
+                pass
 
         self.log.info(f"{total_imported} signatures were imported for source {source}")
 


### PR DESCRIPTION
Closes: https://cccs.atlassian.net/browse/AL-1488

Caused by a limitation of the supported modules from the pysigma library:
https://github.com/CybercentreCanada/pysigma/blob/8c8b77ef8ae831a9d4d6fd95a169741559d511ee/pysigma/signatures.py#L17

The updater won't log these as warnings and just ignore them should they come up.